### PR TITLE
Fixes issues #5, #6, #7, #17, #18, #20, #21, #22

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RNMImport
 Title: Tools for importing and manipulating NONMEM data
-Version: 0.3.6
+Version: 0.3.7
 Author: Mango Solutions <support@mango-solutions.com>
 Maintainer: Gabor Csardi <gcsardi@mango-solutions.com>
 Suggests:

--- a/R/NMBasicModelNM7_factory.R
+++ b/R/NMBasicModelNM7_factory.R
@@ -74,10 +74,10 @@ NMBasicModelNM7 <- function(controlStatements, path, reportContents, dropInputCo
 				corMatrices <- lapply(MethodResults, "[[", "CorrelationMatrix")
 				
 				# grab parameter initial values
-				thetaInitial <- t(controlStatements$Theta)
+				thetaInitial <- t(controlStatements$Theta[,c("Lower","Est","Upper")])
 				
 				# these may be missing in the control statements, so try to extract them from the reportContents
-				omegaInitial <- if(!is.null(controlStatements$Omega)) controlStatements$Omega  else  MethodResults[[1]]$initialEstimates$OMEGA
+				omegaInitial <- if(!is.null(controlStatements$Omega)) controlStatements$Omega$initialMatrix  else  MethodResults[[1]]$initialEstimates$OMEGA
 				
 				# grab dimensions of omega final estimates
 				omegaDim <- dim(MethodResults[[1]]$FinalEstimates$OMEGA)
@@ -91,7 +91,7 @@ NMBasicModelNM7 <- function(controlStatements, path, reportContents, dropInputCo
 				
 				else omegaDimNames <- dimnames(omegaInitial)
 				
-				sigmaInitial <- controlStatements$Sigma
+				sigmaInitial <- controlStatements$Sigma$initialMatrix
 				if(is.null(sigmaInitial)) sigmaInitial <- matrix()
 				rownames(thetaInitial) <- c("lowerBound", "initial", "upperBound")
 				

--- a/R/NMBasicModel_factory.R
+++ b/R/NMBasicModel_factory.R
@@ -57,9 +57,9 @@ NMBasicModel <- function(controlStatements, path, reportContents, dropInputColum
 				covMatrix <- if(!is.null(reportContents$CovarianceMatrix)) CovarianceMatrix else matrix(ncol = 0, nrow = 0)
 				corMatrix <- if(!is.null(reportContents$CorrelationMatrix)) CorrelationMatrix else matrix(ncol = 0, nrow = 0)
 				# grab parameter initial values
-				thetaInitial <- t(controlStatements$Theta)
+				thetaInitial <- t(controlStatements$Theta[,c("Lower","Est","Upper")])
 				# these may be missing in the control statements, so try to extract them from the reportContents
-				omegaInitial <- if(!is.null(controlStatements$Omega)) controlStatements$Omega  else  reportContents$initialEstimates$OMEGA
+				omegaInitial <- if(!is.null(controlStatements$Omega)) controlStatements$Omega$initialMatrix  else  reportContents$initialEstimates$OMEGA
 				# grab dimensions of omega final estimates
 				omegaDim <- dim(FinalEstimates$OMEGA)
 				# if no initial omega, fall back on a default set of names
@@ -70,7 +70,7 @@ NMBasicModel <- function(controlStatements, path, reportContents, dropInputColum
 				
 				else omegaDimNames <- dimnames(omegaInitial)
 				
-				sigmaInitial <- controlStatements$Sigma
+				sigmaInitial <- controlStatements$Sigma$initialMatrix
 				if(is.null(sigmaInitial)) sigmaInitial <- matrix()
 				rownames(thetaInitial) <- c("lowerBound", "initial", "upperBound")
 				

--- a/R/importNmMod.R
+++ b/R/importNmMod.R
@@ -21,6 +21,7 @@
 #' an exception will also be generated. 
 #' @keywords IO
 #' @noRd
+#' @export
 
 importNmMod <- function(
 		fileName = NULL, path = NULL, version = "VI", textReport = FALSE )

--- a/R/importNmModData.R
+++ b/R/importNmModData.R
@@ -32,13 +32,13 @@
         wide <- ynPop( dataSec, "WIDE", default = FALSE, inPlace = TRUE)
         
         ### NULL                                                                    
-        null <- equalExpressionPop( dataSec, "NULL", absent = "", sep="=", inPlace = TRUE)
+        null <- equalExpressionPop( dataSec, "NULL", absent = "", inPlace = TRUE)
         
         ### REWIND, NOREWIND                                                        
         rewind <- ynPop( dataSec, "REWIND", default = FALSE, inPlace=TRUE)
         
         ### records, may be coded NRECS, NRECORDS, RECS, RECORDS                    
-        records <- equalExpressionPop( dataSec, "N?RECO?R?D?S", absent = "", sep="=",inPlace = TRUE)
+        records <- equalExpressionPop( dataSec, "N?RECO?R?D?S", absent = "", inPlace = TRUE)
         
         ### hunt for the IGNORE declaration      
         # this is the regular expression for detecting IGN[ORE] statements (there may be multiple)

--- a/R/importNmModOmega.R
+++ b/R/importNmModOmega.R
@@ -57,6 +57,45 @@
   }
 }
 
+.extractInitialInformation <- function( x, guessNames = TRUE, rx = "([^[:space:]~]+)$")
+{
+  # extract comments	
+  comments <- commentPop( x, inPlace = TRUE )  
+  # check for the presence of "FIXED"
+  fixed <- logicalPop( x, "FIXE?D?", inPlace = TRUE) 
+  
+  ### SAME STYLE                                                              
+  
+  if(logicalPop( x, "SAME", inPlace = TRUE) )  
+    out <- matrix("SAME", 1, 1)
+  else
+  { ### BLOCK style, indicates a block diagonal specification                                                             
+    # retrieve the number of blocks present
+    nBlocks <- equalExpressionPop( x, "BLOCK", sep = "[[:space:]]*", removeBrackets = TRUE, 
+                                   absent =  NULL, inPlace = TRUE)
+    if( !is.null(nBlocks)){        
+      out <- try( .buildSymMatrix( as.numeric( .readValues(x) ) ) )
+    } 
+    else 
+    {  ### DIAG style                                                              
+      equalExpressionPop( x, "DIAG", sep = "[[:space:]]*", inPlace = TRUE )                                                
+      x <- gsub( "[\\(\\)]", "", x )
+      out <- as.numeric( .readValues( x ) )
+      out <- if( length(out)==1) as.matrix(out) else diag(out)
+    }
+    
+  }
+  if( !is.null( comments) && guessNames )
+  {
+    guess <- ogrep( rx, comments, filter = "\\1")
+    guess <- negGrep( "^[[:digit:]]", guess, value = TRUE ) # name should not start with a digit
+    if( length(guess) == nrow(out) ){
+      dimnames(out) <- rep(list(guess), 2)
+    }
+  }
+  out
+}
+
 
 
 .importNmModOmega <- function(
@@ -79,6 +118,8 @@
 	### each $OMEGA is a separate block
 	# this is somewhat complex because omegas can be specified in different ways
 	out <- lapply( omegas, .extractInformation, guessNames = guessNames)
+	mList <- lapply( omegas, .extractInitialInformation, guessNames = guessNames)
+	out$initialMatrix <- blockBind( mList, component, TRUE )
 	out
 	
 }

--- a/R/importNmModOmega.R
+++ b/R/importNmModOmega.R
@@ -63,9 +63,7 @@
 {
   # extract comments	
   comments <- commentPop( x, inPlace = TRUE )  
-  # check for the presence of "FIXED"
-  fixed <- logicalPop( x, "FIXE?D?", inPlace = TRUE) 
-  
+
   ### SAME STYLE                                                              
   
   if(logicalPop( x, "SAME", inPlace = TRUE) )  
@@ -81,6 +79,11 @@
     else 
     {  ### DIAG style                                                              
       equalExpressionPop( x, "DIAG", sep = "[[:space:]]*", inPlace = TRUE )                                                
+      x <- gsub( "[[:space:]]*(FIXE?D?)[[:space:]]*", "FIX", x, ignore.case = TRUE) 
+      x <- regexSplit(x, "\\)?[[:space:]]+\\(?")
+      x <- gsub( "FIX", " FIX ", x ) 
+      fixed <- sapply(x,logicalPop,"FIX", inPlace = TRUE)
+      x <- gsub( "[[:space:]]*(FIXE?D?)[[:space:]]*", "", x, ignore.case = TRUE) 
       x <- gsub( "[\\(\\)]", "", x )
       out <- as.numeric( .readValues( x ) )
       out <- if( length(out)==1) as.matrix(out) else diag(out)

--- a/R/importNmModOmega.R
+++ b/R/importNmModOmega.R
@@ -29,6 +29,7 @@
   }
   else 
   {  ### Independent OMEGAs                                                              
+
     equalExpressionPop( x, "DIAG", sep = "[[:space:]]*", inPlace = TRUE )                                                
     
     # check for the presence of "FIXED"
@@ -40,8 +41,9 @@
     x <- gsub( "[\\(\\)]", "", x )
     values <- as.numeric( .readValues( x ) )
     out <- data.frame(values=values, FIX = fixed)
-    out$comments <- ifelse(length(comments)>0, comments, NA)
-    
+    if ( length(comments)  > 0) out$comments <- comments
+    if ( length(comments) == 0) out$comments <- rep(NA, nrow(out))
+
     if( length( comments)>0 && guessNames )
     {
       guess <- ogrep( rx, comments, filter = "\\1")

--- a/R/importNmModOmega.R
+++ b/R/importNmModOmega.R
@@ -1,42 +1,62 @@
 
 .extractInformation <- function( x, guessNames = TRUE, rx = "([^[:space:]~]+)$")
 {
-	# extract comments	
-	comments <- commentPop( x, inPlace = TRUE )  
-	# check for the presence of "FIXED"
-	fixed <- logicalPop( x, "FIXE?D?", inPlace = TRUE) 
-		
-	### SAME STYLE                                                              
-	
-	if(logicalPop( x, "SAME", inPlace = TRUE) )  
-		out <- matrix("SAME", 1, 1)
-	else
-	{ ### BLOCK style, indicates a block diagonal specification                                                             
-		# retrieve the number of blocks present
-		nBlocks <- equalExpressionPop( x, "BLOCK", sep = "[[:space:]]*", removeBrackets = TRUE, 
-					absent =  NULL, inPlace = TRUE)
-		if( !is.null(nBlocks)){        
-			out <- try( .buildSymMatrix( as.numeric( .readValues(x) ) ) )
-		} 
-		else 
-		{  ### DIAG style                                                              
-				equalExpressionPop( x, "DIAG", sep = "[[:space:]]*", inPlace = TRUE )                                                
-				x <- gsub( "[\\(\\)]", "", x )
-				out <- as.numeric( .readValues( x ) )
-				out <- if( length(out)==1) as.matrix(out) else diag(out)
-		}
-		
-	}
-	if( !is.null( comments) && guessNames )
-	{
-		guess <- ogrep( rx, comments, filter = "\\1")
-		guess <- negGrep( "^[[:digit:]]", guess, value = TRUE ) # name should not start with a digit
-		if( length(guess) == nrow(out) ){
-			dimnames(out) <- rep(list(guess), 2)
-		}
-	}
-	out
+  ### BLOCK style, indicates a block diagonal specification                                                             
+  # retrieve the number of blocks present
+  # extract comments	
+  comments <- stripBlanks( commentPop( x, inPlace = TRUE )  )
+  
+  nBlocks <- equalExpressionPop( x, "BLOCK", sep = "[[:space:]]*", removeBrackets = TRUE , 
+                                 absent =  NULL , inPlace = TRUE)
+  if( !is.null(nBlocks) ){        
+    fixed <- logicalPop( x, "FIXE?D?", inPlace = TRUE )
+    same <- logicalPop( x, "SAME", inPlace = TRUE) 
+    values <- NULL
+    values <- if(!same)try( .buildSymMatrix( as.numeric( .readValues(x) ) ) ) 
+    out <- list(values = values, block=as.numeric(nBlocks), FIX = fixed, SAME = same, comments = comments)
+    if( length( comments)>0 && guessNames )
+    {
+      guess <- ogrep( rx, comments, filter = "\\1")
+      guess <- negGrep( "^[[:digit:]]", guess, value = TRUE ) # name should not start with a digit
+      if( !same && ( length(guess) == nrow(out$values) ) ){
+        dimnames(out$values) <- rep(list(guess), 2)
+      }
+    }
+    else {
+      dimnames(out$values) <- NULL
+    }
+    out
+  }
+  else 
+  {  ### Independent OMEGAs                                                              
+    equalExpressionPop( x, "DIAG", sep = "[[:space:]]*", inPlace = TRUE )                                                
+    
+    # check for the presence of "FIXED"
+    x <- gsub( "[[:space:]]*(FIXE?D?)[[:space:]]*", "FIX", x, ignore.case = TRUE) 
+    x <- regexSplit(x, "\\)?[[:space:]]+\\(?")
+    x <- gsub( "FIX", " FIX ", x ) 
+    fixed <- sapply(x,logicalPop,"FIX", inPlace = TRUE)
+    x <- gsub( "[[:space:]]*(FIXE?D?)[[:space:]]*", "", x, ignore.case = TRUE) 
+    x <- gsub( "[\\(\\)]", "", x )
+    values <- as.numeric( .readValues( x ) )
+    out <- data.frame(values=values, FIX = fixed)
+    out$comments <- ifelse(length(comments)>0, comments, NA)
+    
+    if( length( comments)>0 && guessNames )
+    {
+      guess <- ogrep( rx, comments, filter = "\\1")
+      guess <- negGrep( "^[[:digit:]]", guess, value = TRUE ) # name should not start with a digit
+      if( length(guess) == nrow(out) ){
+        row.names(out) <- guess
+      }
+    }
+    else {
+      row.names(out) <- NULL
+    }
+    out
+  }
 }
+
 
 
 .importNmModOmega <- function(
@@ -58,10 +78,7 @@
 	
 	### each $OMEGA is a separate block
 	# this is somewhat complex because omegas can be specified in different ways
-	mList <- lapply( omegas, .extractInformation, guessNames = guessNames)
-	
-	### structure the output in one single matrix                                 
-	out <- blockBind( mList, component, TRUE )
+	out <- lapply( omegas, .extractInformation, guessNames = guessNames)
 	out
 	
 }

--- a/R/importNmModSim.R
+++ b/R/importNmModSim.R
@@ -28,7 +28,7 @@
 	# determine whether this is data generating-only simulation
 	simOnly <- any(regexMatches(txt, rx = "ONLY"))
 	# TODO: correct the regular expression used to indicate simonly statements
-	listToRemove <- c("NEW", "REQUESTFIRST", "REQUESTSECOND", 
+	listToRemove <- c("REQUESTFIRST", "REQUESTSECOND", 
 			"NOPREDICTION", "PREDICTION", "OMITTED", "ONLYSIMULATION")
 	txt <- killRegex( txt, listToRemove )
 	### extract the seeds                                                         

--- a/R/importNmModSim.R
+++ b/R/importNmModSim.R
@@ -49,7 +49,6 @@
 	
 	### build the output structure                                                
 	out <- c( "nSub" = nSub, "Seed1" = Seed1, "Seed2" = Seed2, "TRUE" = true, "simOnly" = simOnly )
-	attr(out, "rawStatement") <- simStatement
 	out 
 	
 }

--- a/R/importNmModSim.R
+++ b/R/importNmModSim.R
@@ -40,7 +40,7 @@
 	# using shorcut because PROB can be one of : 
 	# NSUBPROBS, NSUBPROBLEMS, SUBPROBLEMS, NPROBLEMS, ...
 	# another way is to use "N?S?U?B?PROBL?E?M?S" instead of "PROB"
-	nSub <- equalExpressionPop( txt, "PROB", absent = 1, shortcut = TRUE, sep = "=", inPlace = TRUE )
+	nSub <- equalExpressionPop( txt, "PROB", absent = 1, shortcut = TRUE, inPlace = TRUE )
 	if( nSub == 1) nSub <- equalExpressionPop( txt, "SUB", absent = 1, shortcut = TRUE, inPlace = TRUE )
 	
 	### the TRUE option                                                           

--- a/R/importNmModTables.R
+++ b/R/importNmModTables.R
@@ -35,11 +35,11 @@
 		x <- gsub("\\)", ".", x)
 		
 		# TODO: If FILE is missing, need to handle this gracefully, since this might be allowed
-		fileName <- equalExpressionPop(x, "FILE", inPlace = TRUE,sep="=")
+		fileName <- equalExpressionPop(x, "FILE", inPlace = TRUE)
 		RNMImportStopifnot(!is.null(fileName), match.call())
 
         ### handle the FORMAT=,1PE11.4 like statements
-        format.of.table = equalExpressionPop(x, "FORMAT", inPlace=TRUE, sep = '=' )
+        format.of.table = equalExpressionPop(x, "FORMAT", inPlace=TRUE)
 
 		### handle the HEADER
 		noHeader <- !ynPop( x, "HEADER", yes.prefix = "ONE", default = TRUE , inPlace = TRUE)

--- a/R/importNmModTheta.R
+++ b/R/importNmModTheta.R
@@ -111,9 +111,9 @@
 			lower <- as.numeric( sub( "^([^,]*),.*", "\\1"         , th ) )   # before the first comma
 			est   <- as.numeric( sub( "^[^,]*,([^,]*),.*", "\\1"   , th ) )   # between comma 1 and 2
 			upper <- as.numeric( sub( "^[^,]*,[^,]*,([^,]*)", "\\1", th ) )   # after comma 2
-			out[i,1] <- lower
+			out[i,1] <- ifelse(is.na(lower), -Inf, lower)
 			out[i,2] <- est
-			out[i,3] <- upper
+			out[i,3] <- ifelse(is.na(upper), Inf, upper)
 		}
 	}  
 	if( guessNames && length(comments) == nrow(out)  )

--- a/R/importNmModTheta.R
+++ b/R/importNmModTheta.R
@@ -125,4 +125,7 @@
 	}
 	out <- data.frame(out) 	
 	out$FIX <- sapply(thetaLines,function(x)logicalPop( x, "FIX", inPlace = TRUE)) 	
+	out$comments <- rep(NA, nrow(out))
+    if(length(comments)>0) { out$comments <- comments }
+    out
 }

--- a/R/importNmModTheta.R
+++ b/R/importNmModTheta.R
@@ -123,5 +123,6 @@
 		alright <- which( regexpr("[\\(\\)]", trythat) == -1 )
 		rownames(out)[rx.out!=-1][alright] <- trythat[alright]
 	}
-	out 	
+	out <- data.frame(out) 	
+	out$FIX <- sapply(thetaLines,function(x)logicalPop( x, "FIX", inPlace = TRUE)) 	
 }

--- a/R/parseutils.R
+++ b/R/parseutils.R
@@ -115,7 +115,7 @@ pop <- function(
 				if(removeBrackets){
 					out <- gsub("[\\(\\)]", "", out)
 				}
-				out
+				trimws(out, which = "both")
 			} 
 			else absent
 	if( numeric) 


### PR DESCRIPTION
I've modified importNmModTheta and importNmModOmega to better parse THETA, OMEGA and SIGMA records when one or more value is fixed (fixes #6 and #7 ). Parsed output is now data frame (THETA) and list (OMEGA, SIGMA). Parsed output includes information for FIX, SAME (in the case of OMEGA, SIGMA) and captures comments. Should facilitate writing these elements back to file and retaining information from the original. Also added @export to importNmMod.R to fix issue #5 . Trim whitespace from the "pop" functions like bracketPop to fix issue #18. Remove "NEW" from listToRemove in importNMModSim to fix issue #17. Remove "rawStatement" attribute from importNmModSim to fix issue #20. Incorporate .extractInformation handling of independent, fixed initial estimates within brackets into .extractInitialInformation function within importNmModOmega to fix issue #21. Fix parsing of nSub in importNmModSim where equalExpressionPop is used with sep="=" instead of using default which includes whitespace to fix #22 .
